### PR TITLE
[BE] 레이블 삭제 기능 구현

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/LabelController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/LabelController.java
@@ -3,7 +3,12 @@ package kr.codesquad.issuetracker.controller;
 import kr.codesquad.issuetracker.dto.LabelResponse;
 import kr.codesquad.issuetracker.service.LabelService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -17,5 +22,15 @@ public class LabelController {
     @GetMapping("/labels")
     public List<LabelResponse> getLabelList() {
         return labelService.getLabelList();
+    }
+
+    @DeleteMapping("/labels/{id}")
+    public ResponseEntity deleteLabel(@PathVariable Long id) {
+        try {
+            labelService.deleteLabel(id);
+        } catch (EmptyResultDataAccessException e) {
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/LabelService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/LabelService.java
@@ -20,4 +20,8 @@ public class LabelService {
         return labelRepository.findAll().stream()
                 .map(LabelResponse::new).collect(Collectors.toList());
     }
+
+    public void deleteLabel(Long id){
+        labelRepository.deleteById(id);
+    }
 }


### PR DESCRIPTION
## ❗️ 이슈 트래킹

- #32 

## 💡 작업목록

- 레이블 삭제 기능 구현

`DELETE api/labels/{id}`
<img width="1007" alt="스크린샷 2022-06-23 오후 2 58 51" src="https://user-images.githubusercontent.com/87681380/175226147-0e580e06-1077-48f0-bba3-39244d8788e6.png">
![스크린샷 2022-06-23 오후 2 58 57](https://user-images.githubusercontent.com/87681380/175226170-b3fdf07c-fbdc-4eda-87b2-29771f0a1722.png)


