### PR TITLE
[Android] 마일스톤 목록 및 추가 구현

### DIFF
--- a/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneDataSource.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneDataSource.kt
@@ -1,0 +1,15 @@
+package com.example.it.issuetracker.data.datasource
+
+import com.example.it.issuetracker.data.dto.MilestoneDto
+import kotlinx.coroutines.flow.Flow
+
+interface MilestoneDataSource {
+
+    fun getMilestoneInfoList(): Flow<List<MilestoneDto>>
+
+    suspend fun addMilestone(milestoneDto: MilestoneDto)
+
+    suspend fun editMilestone(milestoneDto: MilestoneDto)
+
+    suspend fun deleteMilestone(id: Long)
+}

--- a/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneDataSource.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneDataSource.kt
@@ -7,7 +7,7 @@ interface MilestoneDataSource {
 
     fun getMilestoneInfoList(): Flow<List<MilestoneDto>>
 
-    suspend fun addMilestone(milestoneDto: MilestoneDto)
+    suspend fun addMilestone(title: String, description: String, deadline: String)
 
     suspend fun editMilestone(milestoneDto: MilestoneDto)
 

--- a/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneDataSourceDefaultImpl.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneDataSourceDefaultImpl.kt
@@ -1,0 +1,27 @@
+package com.example.it.issuetracker.data.datasource
+
+import com.example.it.issuetracker.data.dto.MilestoneDto
+import com.example.it.issuetracker.data.network.IssueTrackerService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class MilestoneDataSourceDefaultImpl(
+    private val issueTrackerApi: IssueTrackerService
+) : MilestoneDataSource {
+
+    override fun getMilestoneInfoList(): Flow<List<MilestoneDto>> = flow {
+        emit(MilestoneFakeDatabase.getAll())
+    }
+
+    override suspend fun addMilestone(milestoneDto: MilestoneDto) {
+        MilestoneFakeDatabase.add(milestoneDto)
+    }
+
+    override suspend fun editMilestone(milestoneDto: MilestoneDto) {
+        MilestoneFakeDatabase.edit(milestoneDto)
+    }
+
+    override suspend fun deleteMilestone(id: Long) {
+        MilestoneFakeDatabase.delete(id)
+    }
+}

--- a/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneDataSourceDefaultImpl.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneDataSourceDefaultImpl.kt
@@ -13,8 +13,18 @@ class MilestoneDataSourceDefaultImpl(
         emit(MilestoneFakeDatabase.getAll())
     }
 
-    override suspend fun addMilestone(milestoneDto: MilestoneDto) {
-        MilestoneFakeDatabase.add(milestoneDto)
+    override suspend fun addMilestone(title: String, description: String, deadline: String) {
+        MilestoneFakeDatabase.add(
+            MilestoneDto(
+                MilestoneFakeDatabase.size + 1,
+                title,
+                description,
+                "",
+                deadline,
+                null,
+                null
+            )
+        )
     }
 
     override suspend fun editMilestone(milestoneDto: MilestoneDto) {

--- a/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneFakeDatabase.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneFakeDatabase.kt
@@ -36,8 +36,8 @@ object MilestoneFakeDatabase {
         )
     )
 
-    val size: Int
-        get() = database.size
+    val size: Long
+        get() = database.size.toLong()
 
     suspend fun add(milestoneDto: MilestoneDto) {
         delay(1000)

--- a/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneFakeDatabase.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneFakeDatabase.kt
@@ -1,0 +1,59 @@
+package com.example.it.issuetracker.data.datasource
+
+import com.example.it.issuetracker.data.dto.MilestoneDto
+import kotlinx.coroutines.delay
+
+object MilestoneFakeDatabase {
+
+    val database = mutableListOf(
+        MilestoneDto(
+            id = 1,
+            title = "마일스톤",
+            deadLine = "2022-06-14",
+            description = ""
+        ),
+        MilestoneDto(
+            id = 2,
+            title = "마스터즈 코스",
+            deadLine = "2022-06-16",
+            description = ""
+        ),
+        MilestoneDto(
+            id = 3,
+            title = "테스트 그룹",
+            deadLine = "2022-06-17",
+            description = ""
+        ),
+        MilestoneDto(
+            id = 4,
+            title = "마스터즈 코스 숫자",
+            deadLine = "2022-06-20",
+            description = ""
+        )
+    )
+
+    val size: Int
+        get() = database.size
+
+    suspend fun add(milestoneDto: MilestoneDto) {
+        delay(1000)
+        database.add(milestoneDto)
+    }
+
+    suspend fun getAll(): List<MilestoneDto> {
+        delay(1000)
+        return database.toList()
+    }
+
+    suspend fun edit(milestoneDto: MilestoneDto) {
+        delay(1000)
+        val data = database.find { it.id == milestoneDto.id }
+        val index = database.indexOf(data)
+        database[index] = milestoneDto
+    }
+
+    suspend fun delete(id: Long) {
+        val milestoneInfo = database.find { it.id == id }
+        database.remove(milestoneInfo)
+    }
+}

--- a/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneFakeDatabase.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/datasource/MilestoneFakeDatabase.kt
@@ -10,7 +10,9 @@ object MilestoneFakeDatabase {
             id = 1,
             title = "마일스톤",
             deadLine = "2022-06-14",
-            description = ""
+            description = "",
+            openedIssue = 1,
+            closedIssue = 1
         ),
         MilestoneDto(
             id = 2,
@@ -22,12 +24,14 @@ object MilestoneFakeDatabase {
             id = 3,
             title = "테스트 그룹",
             deadLine = "2022-06-17",
-            description = ""
+            description = "",
+            openedIssue = 3,
+            closedIssue = 2
         ),
         MilestoneDto(
             id = 4,
             title = "마스터즈 코스 숫자",
-            deadLine = "2022-06-20",
+            deadLine = null,
             description = ""
         )
     )

--- a/app/src/main/java/com/example/it/issuetracker/data/repository/MilestoneRepositoryImpl.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/repository/MilestoneRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.example.it.issuetracker.data.repository
+
+import com.example.it.issuetracker.data.datasource.MilestoneDataSource
+import com.example.it.issuetracker.data.dto.MilestoneDto
+import com.example.it.issuetracker.domain.repository.MilestoneRepository
+import kotlinx.coroutines.flow.Flow
+
+class MilestoneRepositoryImpl(
+    private val dataSource: MilestoneDataSource
+) : MilestoneRepository {
+
+    override fun getMilestoneInfoList(): Flow<List<MilestoneDto>> {
+        return dataSource.getMilestoneInfoList()
+    }
+
+    override suspend fun addMilestone(milestoneDto: MilestoneDto) {
+        dataSource.addMilestone(milestoneDto)
+    }
+
+    override suspend fun editMilestone(milestoneDto: MilestoneDto) {
+        dataSource.editMilestone(milestoneDto)
+    }
+
+    override suspend fun deleteMilestone(id: Long) {
+        dataSource.deleteMilestone(id)
+    }
+}

--- a/app/src/main/java/com/example/it/issuetracker/data/repository/MilestoneRepositoryImpl.kt
+++ b/app/src/main/java/com/example/it/issuetracker/data/repository/MilestoneRepositoryImpl.kt
@@ -13,8 +13,8 @@ class MilestoneRepositoryImpl(
         return dataSource.getMilestoneInfoList()
     }
 
-    override suspend fun addMilestone(milestoneDto: MilestoneDto) {
-        dataSource.addMilestone(milestoneDto)
+    override suspend fun addMilestone(title: String, description: String ,deadline: String) {
+        dataSource.addMilestone(title, description, deadline)
     }
 
     override suspend fun editMilestone(milestoneDto: MilestoneDto) {

--- a/app/src/main/java/com/example/it/issuetracker/di/datasourceModule.kt
+++ b/app/src/main/java/com/example/it/issuetracker/di/datasourceModule.kt
@@ -1,12 +1,10 @@
 package com.example.it.issuetracker.di
 
-import com.example.it.issuetracker.data.datasource.IssueTrackerDataSource
-import com.example.it.issuetracker.data.datasource.IssueTrackerDefaultDataSource
-import com.example.it.issuetracker.data.datasource.LabelDataSource
-import com.example.it.issuetracker.data.datasource.LabelDataSourceDefaultImpl
+import com.example.it.issuetracker.data.datasource.*
 import org.koin.dsl.module
 
 val dataSourceModule = module {
     single<IssueTrackerDataSource> { IssueTrackerDefaultDataSource() }
     single<LabelDataSource> { LabelDataSourceDefaultImpl(get()) }
+    single<MilestoneDataSource> { MilestoneDataSourceDefaultImpl(get()) }
 }

--- a/app/src/main/java/com/example/it/issuetracker/di/repositoryModule.kt
+++ b/app/src/main/java/com/example/it/issuetracker/di/repositoryModule.kt
@@ -3,13 +3,16 @@ package com.example.it.issuetracker.di
 import com.example.it.issuetracker.data.repository.IssueTrackerRepositoryImpl
 import com.example.it.issuetracker.data.repository.LabelRepositoryImpl
 import com.example.it.issuetracker.data.repository.LoginRepositoryImpl
+import com.example.it.issuetracker.data.repository.MilestoneRepositoryImpl
 import com.example.it.issuetracker.domain.repository.IssueTrackerRepository
 import com.example.it.issuetracker.domain.repository.LabelRepository
 import com.example.it.issuetracker.domain.repository.LoginRepository
+import com.example.it.issuetracker.domain.repository.MilestoneRepository
 import org.koin.dsl.module
 
 val repositoryModule = module {
     single<LoginRepository> { LoginRepositoryImpl(get()) }
     single<LabelRepository> { LabelRepositoryImpl(get()) }
     single<IssueTrackerRepository> { IssueTrackerRepositoryImpl(get()) }
+    single<MilestoneRepository> { MilestoneRepositoryImpl(get()) }
 }

--- a/app/src/main/java/com/example/it/issuetracker/di/viewModelModule.kt
+++ b/app/src/main/java/com/example/it/issuetracker/di/viewModelModule.kt
@@ -4,9 +4,9 @@ import com.example.it.issuetracker.presentation.login.LoginViewModel
 import com.example.it.issuetracker.presentation.main.issue.filter.FilterViewModel
 import com.example.it.issuetracker.presentation.main.issue.list.IssueViewModel
 import com.example.it.issuetracker.presentation.main.issue.search.SearchViewModel
-import com.example.it.issuetracker.presentation.main.label.LabelAddViewModel
+import com.example.it.issuetracker.presentation.main.label.add.LabelAddViewModel
 import com.example.it.issuetracker.presentation.main.label.LabelViewModel
-import com.example.it.issuetracker.presentation.main.milestone.MilestoneAddViewModel
+import com.example.it.issuetracker.presentation.main.milestone.add.MilestoneAddViewModel
 import com.example.it.issuetracker.presentation.main.milestone.MilestoneViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module

--- a/app/src/main/java/com/example/it/issuetracker/di/viewModelModule.kt
+++ b/app/src/main/java/com/example/it/issuetracker/di/viewModelModule.kt
@@ -6,6 +6,7 @@ import com.example.it.issuetracker.presentation.main.issue.list.IssueViewModel
 import com.example.it.issuetracker.presentation.main.issue.search.SearchViewModel
 import com.example.it.issuetracker.presentation.main.label.LabelAddViewModel
 import com.example.it.issuetracker.presentation.main.label.LabelViewModel
+import com.example.it.issuetracker.presentation.main.milestone.MilestoneViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
@@ -16,4 +17,5 @@ val viewModelModule = module {
     viewModel { IssueViewModel(get()) }
     viewModel { FilterViewModel(get(), get(), get()) }
     viewModel { SearchViewModel(get()) }
+    viewModel { MilestoneViewModel(get()) }
 }

--- a/app/src/main/java/com/example/it/issuetracker/di/viewModelModule.kt
+++ b/app/src/main/java/com/example/it/issuetracker/di/viewModelModule.kt
@@ -6,6 +6,7 @@ import com.example.it.issuetracker.presentation.main.issue.list.IssueViewModel
 import com.example.it.issuetracker.presentation.main.issue.search.SearchViewModel
 import com.example.it.issuetracker.presentation.main.label.LabelAddViewModel
 import com.example.it.issuetracker.presentation.main.label.LabelViewModel
+import com.example.it.issuetracker.presentation.main.milestone.MilestoneAddViewModel
 import com.example.it.issuetracker.presentation.main.milestone.MilestoneViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -18,4 +19,5 @@ val viewModelModule = module {
     viewModel { FilterViewModel(get(), get(), get()) }
     viewModel { SearchViewModel(get()) }
     viewModel { MilestoneViewModel(get()) }
+    viewModel { MilestoneAddViewModel(get()) }
 }

--- a/app/src/main/java/com/example/it/issuetracker/domain/model/MileStone.kt
+++ b/app/src/main/java/com/example/it/issuetracker/domain/model/MileStone.kt
@@ -1,5 +1,6 @@
 package com.example.it.issuetracker.domain.model
 
+import com.example.it.issuetracker.data.dto.MilestoneDto
 import com.example.it.issuetracker.presentation.main.issue.list.Mode
 import java.io.Serializable
 
@@ -14,3 +15,15 @@ data class MileStone(
     var isChecked: Boolean = false,
     val mode: Mode = Mode.DEFAULT
 ) : Serializable
+
+fun MileStone.toMileStoneDto(): MilestoneDto {
+    return MilestoneDto(
+        id,
+        title,
+        description,
+        startDate,
+        deadLine,
+        openedIssue,
+        closedIssue
+    )
+}

--- a/app/src/main/java/com/example/it/issuetracker/domain/model/MileStone.kt
+++ b/app/src/main/java/com/example/it/issuetracker/domain/model/MileStone.kt
@@ -1,5 +1,6 @@
 package com.example.it.issuetracker.domain.model
 
+import com.example.it.issuetracker.presentation.main.issue.list.Mode
 import java.io.Serializable
 
 data class MileStone(
@@ -9,5 +10,7 @@ data class MileStone(
     val startDate: String? = null,
     val deadLine: String? = null,
     val openedIssue: Int? = null,
-    val closedIssue: Int? = null
+    val closedIssue: Int? = null,
+    var isChecked: Boolean = false,
+    val mode: Mode = Mode.DEFAULT
 ) : Serializable

--- a/app/src/main/java/com/example/it/issuetracker/domain/repository/MilestoneRepository.kt
+++ b/app/src/main/java/com/example/it/issuetracker/domain/repository/MilestoneRepository.kt
@@ -7,7 +7,7 @@ interface MilestoneRepository {
 
     fun getMilestoneInfoList(): Flow<List<MilestoneDto>>
 
-    suspend fun addMilestone(milestoneDto: MilestoneDto)
+    suspend fun addMilestone(title: String, description: String, deadline: String)
 
     suspend fun editMilestone(milestoneDto: MilestoneDto)
 

--- a/app/src/main/java/com/example/it/issuetracker/domain/repository/MilestoneRepository.kt
+++ b/app/src/main/java/com/example/it/issuetracker/domain/repository/MilestoneRepository.kt
@@ -1,0 +1,15 @@
+package com.example.it.issuetracker.domain.repository
+
+import com.example.it.issuetracker.data.dto.MilestoneDto
+import kotlinx.coroutines.flow.Flow
+
+interface MilestoneRepository {
+
+    fun getMilestoneInfoList(): Flow<List<MilestoneDto>>
+
+    suspend fun addMilestone(milestoneDto: MilestoneDto)
+
+    suspend fun editMilestone(milestoneDto: MilestoneDto)
+
+    suspend fun deleteMilestone(id: Long)
+}

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelAddFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelAddFragment.kt
@@ -28,7 +28,7 @@ class LabelAddFragment : BaseFragment<FragmentLabelAddBinding>(R.layout.fragment
         binding.viewModel = viewModel
         binding.labelAppbarLayout.toolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
-                R.id.label_save -> {
+                R.id.save_string -> {
                     if (editLabelInfo == null) {
                         addLabel()
                     } else {
@@ -74,7 +74,7 @@ class LabelAddFragment : BaseFragment<FragmentLabelAddBinding>(R.layout.fragment
             viewModel.setData(editLabelInfo!!)
         }
 
-        val saveMenu = binding.labelAppbarLayout.toolbar.menu.findItem(R.id.label_save)
+        val saveMenu = binding.labelAppbarLayout.toolbar.menu.findItem(R.id.save_string)
         binding.labelAppbarLayout.toolbar.setNavigationOnClickListener { popBackStack() }
         binding.editSubject.doAfterTextChanged { input ->
             val text = input.toString()

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelAddFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelAddFragment.kt
@@ -26,7 +26,7 @@ class LabelAddFragment : BaseFragment<FragmentLabelAddBinding>(R.layout.fragment
         binding.lifecycleOwner = viewLifecycleOwner
         editLabelInfo = arguments?.getSerializable("label") as? Label
         binding.viewModel = viewModel
-        binding.toolbar.setOnMenuItemClickListener { menuItem ->
+        binding.labelAppbarLayout.toolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 R.id.label_save -> {
                     if (editLabelInfo == null) {
@@ -67,12 +67,15 @@ class LabelAddFragment : BaseFragment<FragmentLabelAddBinding>(R.layout.fragment
     }
 
     override fun initView() {
-        editLabelInfo?.let {
-            viewModel.setData(it)
+        if (editLabelInfo == null) {
+            binding.toolbarTitle = resources.getString(R.string.label_add_string)
+        } else {
+            binding.toolbarTitle = resources.getString(R.string.label_edit_string)
+            viewModel.setData(editLabelInfo!!)
         }
 
-        val saveMenu = binding.toolbar.menu.findItem(R.id.label_save)
-        binding.toolbar.setNavigationOnClickListener { popBackStack() }
+        val saveMenu = binding.labelAppbarLayout.toolbar.menu.findItem(R.id.label_save)
+        binding.labelAppbarLayout.toolbar.setNavigationOnClickListener { popBackStack() }
         binding.editSubject.doAfterTextChanged { input ->
             val text = input.toString()
             saveMenu.isEnabled = text.isNotEmpty()

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelFragment.kt
@@ -10,6 +10,7 @@ import com.example.it.issuetracker.databinding.FragmentLabelBinding
 import com.example.it.issuetracker.domain.model.Label
 import com.example.it.issuetracker.presentation.common.BaseFragment
 import com.example.it.issuetracker.presentation.common.repeatOnLifecycleExtension
+import com.example.it.issuetracker.presentation.main.label.add.LabelAddFragment
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.viewmodel.ext.android.viewModel
 

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelFragment.kt
@@ -55,7 +55,7 @@ class LabelFragment : BaseFragment<FragmentLabelBinding>(R.layout.fragment_label
     private fun setupToolbar() {
         binding.recyclerviewLabelItem.adapter = adapter
         binding.recyclerviewLabelItem.layoutManager = LinearLayoutManager(requireContext())
-        binding.defaultToolbar.setOnMenuItemClickListener { menuItem ->
+        binding.toolbarLayout.defaultToolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 R.id.add_label -> {
                     navigatePage(null)
@@ -65,7 +65,7 @@ class LabelFragment : BaseFragment<FragmentLabelBinding>(R.layout.fragment_label
             }
         }
 
-        binding.editToolbar.setOnMenuItemClickListener { menuItem ->
+        binding.toolbarLayout.editToolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
                 R.id.delete_label -> {
                     viewModel.deleteItems()
@@ -74,7 +74,7 @@ class LabelFragment : BaseFragment<FragmentLabelBinding>(R.layout.fragment_label
                 else -> false
             }
         }
-        binding.editToolbar.setNavigationOnClickListener { viewModel.changeEditMode(false) }
+        binding.toolbarLayout.editToolbar.setNavigationOnClickListener { viewModel.changeEditMode(false) }
     }
 
     private fun navigatePage(label: Label?) {

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/label/LabelFragment.kt
@@ -57,7 +57,7 @@ class LabelFragment : BaseFragment<FragmentLabelBinding>(R.layout.fragment_label
         binding.recyclerviewLabelItem.layoutManager = LinearLayoutManager(requireContext())
         binding.toolbarLayout.defaultToolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
-                R.id.add_label -> {
+                R.id.add_blue_icon -> {
                     navigatePage(null)
                     true
                 }
@@ -67,7 +67,7 @@ class LabelFragment : BaseFragment<FragmentLabelBinding>(R.layout.fragment_label
 
         binding.toolbarLayout.editToolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
-                R.id.delete_label -> {
+                R.id.delete_white_icon -> {
                     viewModel.deleteItems()
                     true
                 }

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/label/add/LabelAddFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/label/add/LabelAddFragment.kt
@@ -1,4 +1,4 @@
-package com.example.it.issuetracker.presentation.main.label
+package com.example.it.issuetracker.presentation.main.label.add
 
 import android.os.Bundle
 import android.view.View

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/label/add/LabelAddViewModel.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/label/add/LabelAddViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.it.issuetracker.presentation.main.label
+package com.example.it.issuetracker.presentation.main.label.add
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAdapter.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAdapter.kt
@@ -1,0 +1,44 @@
+package com.example.it.issuetracker.presentation.main.milestone
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.it.issuetracker.databinding.MilestoneItemBinding
+import com.example.it.issuetracker.domain.model.MileStone
+
+class MilestoneAdapter : ListAdapter<MileStone, MilestoneAdapter.MilestoneViewHolder>(diffUtil) {
+
+    class MilestoneViewHolder(private val binding: MilestoneItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(milestone: MileStone) {
+            binding.milestoneInfo = milestone
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MilestoneViewHolder {
+        return MilestoneViewHolder(
+            MilestoneItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: MilestoneViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+private val diffUtil = object : DiffUtil.ItemCallback<MileStone>() {
+    override fun areItemsTheSame(oldItem: MileStone, newItem: MileStone): Boolean {
+        return oldItem == newItem
+    }
+
+    override fun areContentsTheSame(oldItem: MileStone, newItem: MileStone): Boolean {
+        return oldItem.id == newItem.id
+    }
+}

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAdapter.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAdapter.kt
@@ -2,19 +2,56 @@ package com.example.it.issuetracker.presentation.main.milestone
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.example.it.issuetracker.databinding.MilestoneItemBinding
 import com.example.it.issuetracker.domain.model.MileStone
+import com.example.it.issuetracker.presentation.main.issue.list.Mode
 
-class MilestoneAdapter : ListAdapter<MileStone, MilestoneAdapter.MilestoneViewHolder>(diffUtil) {
+class MilestoneAdapter(
+    private val editModeListener: (editMode: Boolean) -> Unit,
+    private val itemClickListener: (milestone: MileStone) -> Unit,
+) : ListAdapter<MileStone, MilestoneAdapter.MilestoneViewHolder>(diffUtil) {
 
-    class MilestoneViewHolder(private val binding: MilestoneItemBinding) :
-        RecyclerView.ViewHolder(binding.root) {
+    class MilestoneViewHolder(
+        private val binding: MilestoneItemBinding,
+        private val editModeListener: (editMode: Boolean) -> Unit,
+        private val itemClickListener: (milestone: MileStone) -> Unit,
+    ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(milestone: MileStone) {
             binding.milestoneInfo = milestone
+            setItemClickListener(milestone)
+            setItemLayoutChange(milestone)
+        }
+
+        private fun setItemLayoutChange(milestone: MileStone) {
+            binding.cbEdit.setOnCheckedChangeListener { _, isChecked ->
+                milestone.isChecked = isChecked
+            }
+
+            when (milestone.mode) {
+                Mode.DEFAULT -> binding.cbEdit.isVisible = false
+                Mode.EDIT -> binding.cbEdit.isVisible = true
+            }
+        }
+
+        private fun setItemClickListener(milestone: MileStone) {
+            if (milestone.mode == Mode.DEFAULT) {
+                itemView.setOnClickListener {
+                    itemClickListener(milestone)
+                }
+            } else {
+                itemView.setOnClickListener {
+                    binding.cbEdit.isChecked = !binding.cbEdit.isChecked
+                }
+            }
+            itemView.setOnLongClickListener {
+                editModeListener(true)
+                true
+            }
         }
     }
 
@@ -24,7 +61,9 @@ class MilestoneAdapter : ListAdapter<MileStone, MilestoneAdapter.MilestoneViewHo
                 LayoutInflater.from(parent.context),
                 parent,
                 false
-            )
+            ),
+            editModeListener,
+            itemClickListener
         )
     }
 

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddFragment.kt
@@ -12,8 +12,12 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 class MilestoneAddFragment : Fragment() {
 
     private lateinit var binding: FragmentMilestoneAddBinding
-
     private val viewModel by viewModel<MilestoneViewModel>()
+    private var clickSaveListener: (() -> Unit)? = null
+
+    fun setOnClickSaveListener(listener: () -> Unit) {
+        clickSaveListener = listener
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddFragment.kt
@@ -1,39 +1,123 @@
 package com.example.it.issuetracker.presentation.main.milestone
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.fragment.app.Fragment
+import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.FragmentManager
 import com.example.it.issuetracker.R
 import com.example.it.issuetracker.databinding.FragmentMilestoneAddBinding
+import com.example.it.issuetracker.domain.model.MileStone
+import com.example.it.issuetracker.presentation.common.BaseFragment
+import com.example.it.issuetracker.presentation.common.repeatOnLifecycleExtension
+import com.google.android.material.datepicker.MaterialDatePicker
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import java.text.SimpleDateFormat
+import java.util.*
 
-class MilestoneAddFragment : Fragment() {
+class MilestoneAddFragment :
+    BaseFragment<FragmentMilestoneAddBinding>(R.layout.fragment_milestone_add) {
 
-    private lateinit var binding: FragmentMilestoneAddBinding
-    private val viewModel by viewModel<MilestoneViewModel>()
+    private val viewModel by viewModel<MilestoneAddViewModel>()
+    private var editMilestoneInfo: MileStone? = null
     private var clickSaveListener: (() -> Unit)? = null
-
     fun setOnClickSaveListener(listener: () -> Unit) {
         clickSaveListener = listener
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = FragmentMilestoneAddBinding.inflate(inflater)
-        return binding.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        editMilestoneInfo = arguments?.getSerializable("milestone") as? MileStone
+        binding.viewModel = viewModel
 
         initView()
+        observerData()
     }
 
-    private fun initView() {
-        binding.toolbarTitle = resources.getString(R.string.milestone_toolbar_new_string)
+    private fun addMilestone() {
+        viewModel.addMilestone(
+            binding.editSubject.text.toString(),
+            binding.editDescription.text.toString(),
+            binding.editCompleteDate.text.toString(),
+        )
+    }
+
+    private fun editMilestone() {
+        editMilestoneInfo?.let { editMilestone ->
+            val milestoneInfo = editMilestone.copy(
+                title = binding.editSubject.text.toString(),
+                description = binding.editDescription.text.toString(),
+                deadLine = binding.editCompleteDate.text.toString()
+            )
+
+            viewModel.editMilestone(milestoneInfo)
+        }
+    }
+
+    override fun initView() {
+        if (editMilestoneInfo == null) {
+            binding.toolbarTitle = resources.getString(R.string.milestone_add_string)
+        } else {
+            binding.toolbarTitle = resources.getString(R.string.milestone_edit_string)
+            viewModel.setData(editMilestoneInfo!!)
+        }
+
+        val saveMenu = binding.labelAppbarLayout.toolbar.menu.findItem(R.id.save_string)
+        binding.labelAppbarLayout.toolbar.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.save_string -> {
+                    if (editMilestoneInfo == null) {
+                        addMilestone()
+                    } else {
+                        editMilestone()
+                    }
+                    true
+                }
+                else -> false
+            }
+        }
+        binding.labelAppbarLayout.toolbar.setNavigationOnClickListener { popBackStack() }
+        binding.editSubject.doAfterTextChanged { input ->
+            val text = input.toString()
+            saveMenu.isEnabled = text.isNotEmpty()
+            viewModel.title.value = text
+        }
+        binding.editCompleteDate.setOnClickListener {
+            val datePicker = MaterialDatePicker.Builder.datePicker()
+                .setTitleText("날짜를 선택하세요")
+                .build()
+
+            datePicker.addOnPositiveButtonClickListener {
+                binding.editCompleteDate.text = timestampToDateString(it)
+            }
+
+            datePicker.show(parentFragmentManager, "datepicker")
+        }
+    }
+
+    override fun observerData() {
+        repeatOnLifecycleExtension {
+            viewModel.completeSaveLabel.collect { complete ->
+                if (complete) {
+                    clickSaveListener?.invoke()
+                    popBackStack()
+                }
+            }
+        }
+    }
+
+    private fun popBackStack() {
+        parentFragmentManager.popBackStack(
+            "milestone_list",
+            FragmentManager.POP_BACK_STACK_INCLUSIVE
+        )
+    }
+
+    private fun timestampToDateString(timestamp: Long): String {
+        val format = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        format.timeZone = TimeZone.getTimeZone("UTC")
+        format.isLenient = false
+
+        return format.format(Date(timestamp))
     }
 }

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddFragment.kt
@@ -1,0 +1,32 @@
+package com.example.it.issuetracker.presentation.main.milestone
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.example.it.issuetracker.R
+import com.example.it.issuetracker.databinding.FragmentMilestoneAddBinding
+
+class MilestoneAddFragment : Fragment() {
+
+    private lateinit var binding: FragmentMilestoneAddBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentMilestoneAddBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initView()
+    }
+
+    private fun initView() {
+        binding.toolbarTitle = resources.getString(R.string.milestone_toolbar_new_string)
+    }
+}

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddFragment.kt
@@ -7,10 +7,13 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.example.it.issuetracker.R
 import com.example.it.issuetracker.databinding.FragmentMilestoneAddBinding
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MilestoneAddFragment : Fragment() {
 
     private lateinit var binding: FragmentMilestoneAddBinding
+
+    private val viewModel by viewModel<MilestoneViewModel>()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddViewModel.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneAddViewModel.kt
@@ -1,0 +1,55 @@
+package com.example.it.issuetracker.presentation.main.milestone
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.it.issuetracker.domain.model.MileStone
+import com.example.it.issuetracker.domain.model.toMileStoneDto
+import com.example.it.issuetracker.domain.repository.MilestoneRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class MilestoneAddViewModel(
+    private val milestoneRepository: MilestoneRepository
+) : ViewModel() {
+
+    var title = MutableStateFlow("")
+
+    var description = MutableStateFlow("")
+
+    var deadline = MutableStateFlow("")
+
+    private var _completeSaveLabel = MutableStateFlow(false)
+    val completeSaveLabel = _completeSaveLabel.asStateFlow()
+
+    fun addMilestone(title: String, description: String, deadline: String) {
+        _completeSaveLabel.value = false
+        this.title.value = title
+
+        this.description.value = description
+
+        this.deadline.value = deadline
+
+        viewModelScope.launch {
+            milestoneRepository.addMilestone(title, description, deadline)
+            _completeSaveLabel.value = true
+        }
+    }
+
+    fun editMilestone(milestone: MileStone) {
+        viewModelScope.launch {
+            milestoneRepository.editMilestone(milestone.toMileStoneDto())
+            _completeSaveLabel.value = true
+        }
+    }
+
+    fun setData(milestone: MileStone) {
+        this.title.value = milestone.title
+        this.description.value = milestone.description!!
+        this.deadline.value = milestone.deadLine!!
+    }
+
+    fun clearDeadline() {
+        this.deadline.value = ""
+    }
+}

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
@@ -1,53 +1,98 @@
 package com.example.it.issuetracker.presentation.main.milestone
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.fragment.app.Fragment
+import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
-import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.RecyclerView
 import com.example.it.issuetracker.R
 import com.example.it.issuetracker.databinding.FragmentMilestoneBinding
+import com.example.it.issuetracker.domain.model.MileStone
+import com.example.it.issuetracker.presentation.common.BaseFragment
+import com.example.it.issuetracker.presentation.common.repeatOnLifecycleExtension
+import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class MilestoneFragment : Fragment() {
-
-    private lateinit var binding: FragmentMilestoneBinding
+class MilestoneFragment : BaseFragment<FragmentMilestoneBinding>(R.layout.fragment_milestone) {
 
     private val viewModel by viewModel<MilestoneViewModel>()
 
-    private val adapter = MilestoneAdapter()
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?,
-    ): View {
-        binding = FragmentMilestoneBinding.inflate(inflater)
-        binding.lifecycleOwner = this.viewLifecycleOwner
-        return binding.root
-    }
+    private val adapter = MilestoneAdapter({ viewModel.changeEditMode(it) }, { navigatePage(it) })
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewModel = viewModel
 
+        setupToolbar()
+        viewModel.getMilestoneInfoList()
         initView()
+        observerData()
     }
 
-    private fun initView() {
-        binding.toolbarLayout.defaultToolbar.setOnMenuItemClickListener { menu ->
-            when (menu.itemId) {
+    override fun observerData() {
+        repeatOnLifecycleExtension {
+            viewModel.milestoneList.collectLatest {
+                adapter.submitList(it)
+            }
+        }
+
+        repeatOnLifecycleExtension {
+            viewModel.completeDelete.collect { complete ->
+                if (complete) {
+                    viewModel.getMilestoneInfoList()
+                    viewModel.changeEditMode(false)
+                }
+            }
+        }
+    }
+
+    override fun initView() {
+        binding.recyclerviewMilestoneItem.adapter = adapter
+        val dividerItemDecoration = DividerItemDecoration(requireContext(), RecyclerView.VERTICAL)
+        binding.recyclerviewMilestoneItem.addItemDecoration(dividerItemDecoration)
+        setupToolbar()
+        viewModel.start()
+    }
+
+    private fun setupToolbar() {
+        binding.toolbarLayout.defaultToolbar.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
                 R.id.add_blue_icon -> {
-                    val addFragment = MilestoneAddFragment()
-                    parentFragmentManager.commit {
-                        addToBackStack("milestone_add")
-                        replace(R.id.container_main, addFragment)
-                    }
+                    navigatePage(null)
                     true
                 }
                 else -> false
             }
         }
-        binding.recyclerviewMilestoneItem.adapter = adapter
+
+        binding.toolbarLayout.editToolbar.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.delete_white_icon -> {
+                    viewModel.deleteItems()
+                    true
+                }
+                else -> false
+            }
+        }
+        binding.toolbarLayout.editToolbar.setNavigationOnClickListener {
+            viewModel.changeEditMode(
+                false
+            )
+        }
+    }
+
+    private fun navigatePage(milestone: MileStone?) {
+        val addFragment = MilestoneAddFragment()
+        addFragment.setOnClickSaveListener { viewModel.getMilestoneInfoList() }
+        parentFragmentManager.commit {
+            addToBackStack("milestone_list")
+            if (milestone == null) replace(R.id.container_main, addFragment)
+            else {
+                addFragment.arguments = bundleOf("milestone" to milestone)
+                replace(R.id.container_main, addFragment)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
@@ -11,6 +11,7 @@ import com.example.it.issuetracker.databinding.FragmentMilestoneBinding
 import com.example.it.issuetracker.domain.model.MileStone
 import com.example.it.issuetracker.presentation.common.BaseFragment
 import com.example.it.issuetracker.presentation.common.repeatOnLifecycleExtension
+import com.example.it.issuetracker.presentation.main.milestone.add.MilestoneAddFragment
 import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.viewmodel.ext.android.viewModel
 

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
@@ -6,12 +6,16 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
+import androidx.fragment.app.viewModels
 import com.example.it.issuetracker.R
 import com.example.it.issuetracker.databinding.FragmentMilestoneBinding
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MilestoneFragment : Fragment() {
 
     private lateinit var binding: FragmentMilestoneBinding
+
+    private val viewModel by viewModel<MilestoneViewModel>()
 
     private val adapter = MilestoneAdapter()
 

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
@@ -13,6 +13,8 @@ class MilestoneFragment : Fragment() {
 
     private lateinit var binding: FragmentMilestoneBinding
 
+    private val adapter = MilestoneAdapter()
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
@@ -42,5 +44,6 @@ class MilestoneFragment : Fragment() {
                 else -> false
             }
         }
+        binding.recyclerviewMilestoneItem.adapter = adapter
     }
 }

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
@@ -1,19 +1,25 @@
 package com.example.it.issuetracker.presentation.main.milestone
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.example.it.issuetracker.R
+import com.example.it.issuetracker.databinding.FragmentMilestoneBinding
+import com.example.it.issuetracker.presentation.main.label.LabelListAdapter
 
 class MilestoneFragment : Fragment() {
+
+    private lateinit var binding: FragmentMilestoneBinding
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_milestone, container, false)
+    ): View {
+        binding = FragmentMilestoneBinding.inflate(inflater)
+        binding.lifecycleOwner = this.viewLifecycleOwner
+        return binding.root
     }
 }

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneFragment.kt
@@ -1,14 +1,13 @@
 package com.example.it.issuetracker.presentation.main.milestone
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.commit
 import com.example.it.issuetracker.R
 import com.example.it.issuetracker.databinding.FragmentMilestoneBinding
-import com.example.it.issuetracker.presentation.main.label.LabelListAdapter
 
 class MilestoneFragment : Fragment() {
 
@@ -21,5 +20,27 @@ class MilestoneFragment : Fragment() {
         binding = FragmentMilestoneBinding.inflate(inflater)
         binding.lifecycleOwner = this.viewLifecycleOwner
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initView()
+    }
+
+    private fun initView() {
+        binding.toolbarLayout.defaultToolbar.setOnMenuItemClickListener { menu ->
+            when (menu.itemId) {
+                R.id.add_blue_icon -> {
+                    val addFragment = MilestoneAddFragment()
+                    parentFragmentManager.commit {
+                        addToBackStack("milestone_add")
+                        replace(R.id.container_main, addFragment)
+                    }
+                    true
+                }
+                else -> false
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneViewModel.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneViewModel.kt
@@ -1,0 +1,10 @@
+package com.example.it.issuetracker.presentation.main.milestone
+
+import androidx.lifecycle.ViewModel
+import com.example.it.issuetracker.domain.repository.MilestoneRepository
+
+class MilestoneViewModel(
+    private val milestoneRepository: MilestoneRepository
+) : ViewModel() {
+
+}

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneViewModel.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/MilestoneViewModel.kt
@@ -1,10 +1,77 @@
 package com.example.it.issuetracker.presentation.main.milestone
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.it.issuetracker.data.dto.toMilestone
+import com.example.it.issuetracker.domain.model.MileStone
 import com.example.it.issuetracker.domain.repository.MilestoneRepository
+import com.example.it.issuetracker.presentation.main.issue.list.Mode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 class MilestoneViewModel(
     private val milestoneRepository: MilestoneRepository
 ) : ViewModel() {
 
+    private var _milestoneList = MutableStateFlow<List<MileStone>>(emptyList())
+    val milestoneList = _milestoneList.asStateFlow()
+
+    private var _dataLoading = MutableStateFlow(false)
+    val dataLoading = _dataLoading.asStateFlow()
+
+    private var _editMode = MutableStateFlow(false)
+    val editMode = _editMode.asStateFlow()
+
+    private var _completeDelete = MutableStateFlow(false)
+    val completeDelete = _completeDelete.asStateFlow()
+
+    private var hasData = false
+
+    fun start() {
+        if (!hasData) {
+            getMilestoneInfoList()
+            hasData = true
+        }
+    }
+
+    fun getMilestoneInfoList() {
+        viewModelScope.launch(Dispatchers.IO) {
+            _dataLoading.value = true
+            milestoneRepository.getMilestoneInfoList().collectLatest { milestoneDtoList ->
+                _milestoneList.value = milestoneDtoList.map { dto -> dto.toMilestone() }
+                _dataLoading.value = false
+            }
+        }
+        _completeDelete.value = false
+    }
+
+    fun changeEditMode(editMode: Boolean) {
+        if (editMode == _editMode.value) return
+
+        val editModeList = _milestoneList.value.map {
+            if (it.mode == Mode.DEFAULT) {
+                it.copy(mode = Mode.EDIT)
+            } else {
+                it.copy(mode = Mode.DEFAULT)
+            }
+        }
+
+        _editMode.value = editMode
+        _milestoneList.value = editModeList
+    }
+
+    fun deleteItems() {
+        _completeDelete.value = false
+        viewModelScope.launch {
+            _milestoneList.value.filter {
+                it.isChecked
+            }.forEach {
+                milestoneRepository.deleteMilestone(it.id)
+            }
+        }
+        _completeDelete.value = true
+    }
 }

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/add/MilestoneAddFragment.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/add/MilestoneAddFragment.kt
@@ -1,4 +1,4 @@
-package com.example.it.issuetracker.presentation.main.milestone
+package com.example.it.issuetracker.presentation.main.milestone.add
 
 import android.os.Bundle
 import android.view.View

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/add/MilestoneAddViewModel.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/add/MilestoneAddViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.it.issuetracker.presentation.main.milestone
+package com.example.it.issuetracker.presentation.main.milestone.add
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/add/MilestoneAddViewModel.kt
+++ b/app/src/main/java/com/example/it/issuetracker/presentation/main/milestone/add/MilestoneAddViewModel.kt
@@ -45,8 +45,12 @@ class MilestoneAddViewModel(
 
     fun setData(milestone: MileStone) {
         this.title.value = milestone.title
-        this.description.value = milestone.description!!
-        this.deadline.value = milestone.deadLine!!
+        if (milestone.description != null) {
+            this.description.value = milestone.description
+        }
+        if (milestone.deadLine != null) {
+            this.deadline.value = milestone.deadLine
+        }
     }
 
     fun clearDeadline() {

--- a/app/src/main/res/drawable/ic_calendar_gray.xml
+++ b/app/src/main/res/drawable/ic_calendar_gray.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#8E8E93"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,3h-1L19,1h-2v2L7,3L7,1L5,1v2L4,3c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,5c0,-1.1 -0.9,-2 -2,-2zM20,21L4,21L4,10h16v11zM20,8L4,8L4,5h16v3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_close_blue.xml
+++ b/app/src/main/res/drawable/ic_close_blue.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="21dp"
+    android:height="20dp"
+    android:viewportWidth="21"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="#0025E7"
+        android:pathData="M1.655,20V6.7H0.686V0H20.062V6.7H19.094V20H1.655ZM3.593,18H17.156V7H3.593V18ZM2.624,5H18.125V2H2.624V5ZM7.468,12H13.281V10H7.468V12ZM3.593,18V7V18Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_exit_grey.xml
+++ b/app/src/main/res/drawable/ic_exit_grey.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#87878D"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_info_blue.xml
+++ b/app/src/main/res/drawable/ic_info_blue.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#004DE3"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_label.xml
+++ b/app/src/main/res/layout/fragment_label.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:bind="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -18,39 +19,12 @@
         android:layout_height="match_parent"
         tools:context=".presentation.main.label.LabelFragment">
 
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/label_appbarLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:elevation="0dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/default_toolbar"
-                style="@style/Headline6"
-                android:layout_width="match_parent"
-                android:layout_height="?android:actionBarSize"
-                android:background="@color/white"
-                android:visibility="@{viewModel.editMode? View.GONE : View.VISIBLE}"
-                app:menu="@menu/label_default_menu"
-                app:title="@string/label_string" />
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/edit_toolbar"
-                style="@style/Headline6"
-                android:layout_width="match_parent"
-                android:layout_height="?android:actionBarSize"
-                android:background="@color/main"
-                android:visibility="@{viewModel.editMode? View.VISIBLE : View.GONE}"
-                app:menu="@menu/label_edit_menu"
-                app:navigationIcon="@drawable/ic_exit"
-                app:title="@string/select_label"
-                app:titleTextColor="@color/white"
-                tools:visibility="gone" />
-
-        </com.google.android.material.appbar.AppBarLayout>
+        <include
+            android:id="@+id/toolbar_layout"
+            layout="@layout/toolbar_edit_layout"
+            bind:defaultToolbarTitle="@{@string/label_string}"
+            bind:editToolbarTitle="@{@string/select_label}"
+            bind:editToolbarVisible="@{viewModel.editMode}" />
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/refresh_layout"
@@ -60,7 +34,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_appbarLayout"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_layout"
             app:onRefreshListener="@{viewModel::getLabelInfoList}"
             app:refreshing="@{viewModel.dataLoading}">
 

--- a/app/src/main/res/layout/fragment_label.xml
+++ b/app/src/main/res/layout/fragment_label.xml
@@ -42,12 +42,8 @@
                 android:id="@+id/recyclerview_label_item"
                 style="@style/Body2"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
+                android:layout_height="match_parent"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/label_appbarLayout"
                 tools:listitem="@layout/label_item" />
 
         </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/fragment_label_add.xml
+++ b/app/src/main/res/layout/fragment_label_add.xml
@@ -14,14 +14,14 @@
 
         <variable
             name="viewModel"
-            type="com.example.it.issuetracker.presentation.main.label.LabelAddViewModel" />
+            type="com.example.it.issuetracker.presentation.main.label.add.LabelAddViewModel" />
 
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".presentation.main.label.LabelAddFragment">
+        tools:context=".presentation.main.label.add.LabelAddFragment">
 
         <include
             android:id="@+id/label_appbarLayout"

--- a/app/src/main/res/layout/fragment_label_add.xml
+++ b/app/src/main/res/layout/fragment_label_add.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:bind="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
         <import type="android.graphics.Color" />
+
+        <variable
+            name="toolbarTitle"
+            type="String" />
 
         <variable
             name="viewModel"
@@ -18,27 +23,10 @@
         android:layout_height="match_parent"
         tools:context=".presentation.main.label.LabelAddFragment">
 
-        <com.google.android.material.appbar.AppBarLayout
+        <include
             android:id="@+id/label_appbarLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:elevation="0dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
-                style="@style/Headline6"
-                android:layout_width="match_parent"
-                android:layout_height="?android:actionBarSize"
-                android:background="@color/main"
-                app:menu="@menu/label_add_menu"
-                app:navigationIcon="@drawable/ic_back"
-                app:title="@string/label_add_string"
-                app:titleTextColor="@color/white" />
-
-        </com.google.android.material.appbar.AppBarLayout>
+            bind:title="@{toolbarTitle}"
+            layout="@layout/toolbar_add_layout" />
 
         <TextView
             android:id="@+id/tv_subject"

--- a/app/src/main/res/layout/fragment_milestone.xml
+++ b/app/src/main/res/layout/fragment_milestone.xml
@@ -1,14 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".presentation.main.milestone.MilestoneFragment">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:bind="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="Milestone" />
+        tools:context=".presentation.main.milestone.MilestoneFragment">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <include
+            android:id="@+id/toolbar_layout"
+            layout="@layout/toolbar_edit_layout"
+            bind:defaultToolbarTitle="@{@string/milestone_toolbar_title_string}"
+            bind:editToolbarTitle="@{@string/milestone_toolbar_edit_string}"
+            bind:editToolbarVisible="@{false}" />
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/refresh_layout"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_layout">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerview_milestone_item"
+                style="@style/Body2"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/milestone_item" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_milestone.xml
+++ b/app/src/main/res/layout/fragment_milestone.xml
@@ -6,6 +6,10 @@
 
     <data>
 
+        <variable
+            name="viewModel"
+            type="com.example.it.issuetracker.presentation.main.milestone.MilestoneViewModel" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -18,16 +22,19 @@
             layout="@layout/toolbar_edit_layout"
             bind:defaultToolbarTitle="@{@string/milestone_toolbar_title_string}"
             bind:editToolbarTitle="@{@string/milestone_toolbar_edit_string}"
-            bind:editToolbarVisible="@{false}" />
+            bind:editToolbarVisible="@{viewModel.editMode}" />
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/refresh_layout"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            app:enabled="@{!viewModel.editMode}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar_layout">
+            app:layout_constraintTop_toBottomOf="@id/toolbar_layout"
+            app:onRefreshListener="@{viewModel::getMilestoneInfoList}"
+            app:refreshing="@{viewModel.dataLoading}">
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/recyclerview_milestone_item"

--- a/app/src/main/res/layout/fragment_milestone_add.xml
+++ b/app/src/main/res/layout/fragment_milestone_add.xml
@@ -12,14 +12,14 @@
 
         <variable
             name="viewModel"
-            type="com.example.it.issuetracker.presentation.main.milestone.MilestoneAddViewModel" />
+            type="com.example.it.issuetracker.presentation.main.milestone.add.MilestoneAddViewModel" />
 
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".presentation.main.milestone.MilestoneAddFragment">
+        tools:context=".presentation.main.milestone.add.MilestoneAddFragment">
 
         <include
             android:id="@+id/label_appbarLayout"

--- a/app/src/main/res/layout/fragment_milestone_add.xml
+++ b/app/src/main/res/layout/fragment_milestone_add.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:bind="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="toolbarTitle"
+            type="String" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.main.milestone.MilestoneAddFragment">
+
+        <include
+            android:id="@+id/label_appbarLayout"
+            layout="@layout/toolbar_add_layout"
+            bind:title="@{toolbarTitle}" />
+
+        <TextView
+            android:id="@+id/tv_subject"
+            style="@style/Body2"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="22dp"
+            android:text="@string/label_subject_string"
+            android:textColor="@color/dark_gray"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_appbarLayout" />
+
+        <EditText
+            android:id="@+id/edit_subject"
+            style="@style/Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="16dp"
+            android:background="@android:color/transparent"
+            android:hint="@string/must_input_string"
+            app:layout_constraintBottom_toBottomOf="@id/tv_subject"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_subject"
+            app:layout_constraintTop_toTopOf="@id/tv_subject" />
+
+        <TextView
+            android:id="@+id/tv_description"
+            style="@style/Body2"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="33dp"
+            android:text="@string/description_string"
+            android:textColor="@color/dark_gray"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_subject" />
+
+        <EditText
+            android:id="@+id/edit_description"
+            style="@style/Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="16dp"
+            android:background="@android:color/transparent"
+            android:hint="@string/optional_input_string"
+            app:layout_constraintBottom_toBottomOf="@id/tv_description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_description"
+            app:layout_constraintTop_toTopOf="@id/tv_description" />
+
+        <TextView
+            android:id="@+id/tv_complete_date"
+            style="@style/Body2"
+            android:layout_width="60dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="33dp"
+            android:text="@string/milestone_complete_date"
+            android:textColor="@color/dark_gray"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_description" />
+
+        <TextView
+            android:id="@+id/edit_complete_date"
+            style="@style/Body2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_marginEnd="16dp"
+            android:background="@android:color/transparent"
+            android:textColor="@color/dark_gray"
+            android:hint="@string/optional_input_date_string"
+            app:layout_constraintBottom_toBottomOf="@id/tv_complete_date"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_complete_date"
+            app:layout_constraintTop_toTopOf="@id/tv_complete_date" />
+
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="22dp"
+            android:background="@color/gray"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/edit_complete_date" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_milestone_add.xml
+++ b/app/src/main/res/layout/fragment_milestone_add.xml
@@ -10,6 +10,10 @@
             name="toolbarTitle"
             type="String" />
 
+        <variable
+            name="viewModel"
+            type="com.example.it.issuetracker.presentation.main.milestone.MilestoneAddViewModel" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -43,6 +47,7 @@
             android:layout_marginEnd="16dp"
             android:background="@android:color/transparent"
             android:hint="@string/must_input_string"
+            android:text="@{viewModel.title}"
             app:layout_constraintBottom_toBottomOf="@id/tv_subject"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_subject"
@@ -69,6 +74,7 @@
             android:layout_marginEnd="16dp"
             android:background="@android:color/transparent"
             android:hint="@string/optional_input_string"
+            android:text="@{viewModel.description}"
             app:layout_constraintBottom_toBottomOf="@id/tv_description"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_description"
@@ -92,15 +98,28 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="4dp"
-            android:layout_marginEnd="16dp"
+            android:layout_marginEnd="4dp"
             android:background="@android:color/transparent"
-            android:textColor="@color/dark_gray"
             android:hint="@string/optional_input_date_string"
+            android:text="@{viewModel.deadline}"
+            android:textColor="@color/dark_gray"
             app:layout_constraintBottom_toBottomOf="@id/tv_complete_date"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/btn_clear_date"
             app:layout_constraintStart_toEndOf="@id/tv_complete_date"
             app:layout_constraintTop_toTopOf="@id/tv_complete_date" />
 
+        <ImageButton
+            android:id="@+id/btn_clear_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="@string/clear_date_string"
+            android:onClick="@{() -> viewModel.clearDeadline()}"
+            android:src="@drawable/ic_exit_grey"
+            app:layout_constraintBottom_toBottomOf="@id/edit_complete_date"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/edit_complete_date" />
 
         <View
             android:id="@+id/divider"

--- a/app/src/main/res/layout/milestone_item.xml
+++ b/app/src/main/res/layout/milestone_item.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp">
+
+        <TextView
+            android:id="@+id/tv_subject"
+            style="@style/Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:fontFamily="@font/noto_sans_kr"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@id/tv_progress_value"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="제목" />
+
+        <TextView
+            android:id="@+id/tv_progress_value"
+            style="@style/Subtitle1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/light_green"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/tv_subject"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/tv_subject"
+            tools:text="진행률(%)" />
+
+        <TextView
+            android:id="@+id/tv_description"
+            style="@style/Subtitle2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/dark_gray"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_subject"
+            tools:text="마일스톤에 대한 설명 (한 줄만 보여짐, 생략 가능)" />
+
+        <ImageView
+            android:id="@+id/iv_calendar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:contentDescription="@string/calendar_image_content"
+            android:src="@drawable/ic_calendar_gray"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_description" />
+
+        <TextView
+            android:id="@+id/tv_deadline"
+            style="@style/Subtitle2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textColor="@color/dark_gray"
+            app:layout_constraintBottom_toBottomOf="@id/iv_calendar"
+            app:layout_constraintStart_toEndOf="@id/iv_calendar"
+            app:layout_constraintTop_toTopOf="@id/iv_calendar"
+            tools:text="완료일(생략 가능)" />
+
+        <com.google.android.material.chip.ChipGroup
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_deadline">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_open_issue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:textColor="@color/open_issue_text_color"
+                app:chipBackgroundColor="@color/open_issue_bg_color"
+                app:chipIcon="@drawable/ic_info_blue"
+                app:chipIconSize="20dp"
+                app:chipStrokeColor="@color/open_issue_text_color"
+                app:chipStrokeWidth="1dp"
+                app:iconStartPadding="5dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_deadline"
+                tools:text="열린 이슈 1개" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chip_close_issue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:textColor="@color/close_issue_text_color"
+                app:chipBackgroundColor="@color/close_issue_bg_color"
+                app:chipIcon="@drawable/ic_close_blue"
+                app:chipIconSize="15dp"
+                app:chipStrokeColor="@color/close_issue_text_color"
+                app:chipStrokeWidth="1dp"
+                app:iconStartPadding="5dp"
+                app:layout_constraintStart_toEndOf="@id/chip_open_issue"
+                app:layout_constraintTop_toBottomOf="@id/tv_deadline"
+                tools:text="닫힌 이슈 1개" />
+        </com.google.android.material.chip.ChipGroup>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/milestone_item.xml
+++ b/app/src/main/res/layout/milestone_item.xml
@@ -7,6 +7,8 @@
 
         <import type="android.view.View" />
 
+        <import type="android.text.TextUtils" />
+
         <variable
             name="milestoneInfo"
             type="com.example.it.issuetracker.domain.model.MileStone" />
@@ -84,7 +86,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:text="@{milestoneInfo.deadLine==null? @string/not_deadline_string : milestoneInfo.deadLine}"
+            android:text="@{TextUtils.isEmpty(milestoneInfo.deadLine)? @string/not_deadline_string : milestoneInfo.deadLine}"
             android:textColor="@color/dark_gray"
             app:layout_constraintBottom_toBottomOf="@id/iv_calendar"
             app:layout_constraintStart_toEndOf="@id/iv_calendar"

--- a/app/src/main/res/layout/milestone_item.xml
+++ b/app/src/main/res/layout/milestone_item.xml
@@ -5,6 +5,10 @@
 
     <data>
 
+        <variable
+            name="milestoneInfo"
+            type="com.example.it.issuetracker.domain.model.MileStone" />
+
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/milestone_item.xml
+++ b/app/src/main/res/layout/milestone_item.xml
@@ -5,6 +5,8 @@
 
     <data>
 
+        <import type="android.view.View" />
+
         <variable
             name="milestoneInfo"
             type="com.example.it.issuetracker.domain.model.MileStone" />
@@ -16,6 +18,15 @@
         android:layout_height="wrap_content"
         android:layout_margin="16dp">
 
+        <CheckBox
+            android:id="@+id/cb_edit"
+            android:layout_width="129dp"
+            android:layout_height="0dp"
+            android:checked="@{milestoneInfo.isChecked}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <TextView
             android:id="@+id/tv_subject"
             style="@style/Subtitle1"
@@ -23,9 +34,10 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
             android:fontFamily="@font/noto_sans_kr"
+            android:text="@{milestoneInfo.title}"
             android:textStyle="bold"
             app:layout_constraintEnd_toStartOf="@id/tv_progress_value"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toEndOf="@id/cb_edit"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="제목" />
 
@@ -44,14 +56,15 @@
         <TextView
             android:id="@+id/tv_description"
             style="@style/Subtitle2"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:ellipsize="end"
             android:maxLines="1"
+            android:text="@{milestoneInfo.description}"
             android:textColor="@color/dark_gray"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_subject"
             app:layout_constraintTop_toBottomOf="@id/tv_subject"
             tools:text="마일스톤에 대한 설명 (한 줄만 보여짐, 생략 가능)" />
 
@@ -62,7 +75,7 @@
             android:layout_marginTop="8dp"
             android:contentDescription="@string/calendar_image_content"
             android:src="@drawable/ic_calendar_gray"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_subject"
             app:layout_constraintTop_toBottomOf="@id/tv_description" />
 
         <TextView
@@ -71,6 +84,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
+            android:text="@{milestoneInfo.deadLine==null? @string/not_deadline_string : milestoneInfo.deadLine}"
             android:textColor="@color/dark_gray"
             app:layout_constraintBottom_toBottomOf="@id/iv_calendar"
             app:layout_constraintStart_toEndOf="@id/iv_calendar"
@@ -81,7 +95,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_subject"
             app:layout_constraintTop_toBottomOf="@id/tv_deadline">
 
             <com.google.android.material.chip.Chip
@@ -89,12 +103,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
+                android:visibility="@{milestoneInfo.openedIssue==null? View.GONE : View.VISIBLE}"
                 android:textColor="@color/open_issue_text_color"
                 app:chipBackgroundColor="@color/open_issue_bg_color"
                 app:chipIcon="@drawable/ic_info_blue"
                 app:chipIconSize="20dp"
                 app:chipStrokeColor="@color/open_issue_text_color"
                 app:chipStrokeWidth="1dp"
+                android:text="@{@string/open_issue_string(milestoneInfo.openedIssue)}"
                 app:iconStartPadding="5dp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/tv_deadline"
@@ -105,11 +121,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
+                android:visibility="@{milestoneInfo.closedIssue==null? View.GONE : View.VISIBLE}"
                 android:textColor="@color/close_issue_text_color"
                 app:chipBackgroundColor="@color/close_issue_bg_color"
                 app:chipIcon="@drawable/ic_close_blue"
                 app:chipIconSize="15dp"
                 app:chipStrokeColor="@color/close_issue_text_color"
+                android:text="@{@string/close_issue_string(milestoneInfo.closedIssue)}"
                 app:chipStrokeWidth="1dp"
                 app:iconStartPadding="5dp"
                 app:layout_constraintStart_toEndOf="@id/chip_open_issue"

--- a/app/src/main/res/layout/toolbar_add_layout.xml
+++ b/app/src/main/res/layout/toolbar_add_layout.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="title"
+            type="String" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/label_appbarLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:elevation="0dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                style="@style/Headline6"
+                android:layout_width="match_parent"
+                android:layout_height="?android:actionBarSize"
+                android:background="@color/main"
+                app:menu="@menu/label_add_menu"
+                app:navigationIcon="@drawable/ic_back"
+                app:title="@{title}"
+                app:titleTextColor="@color/white"/>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/toolbar_add_layout.xml
+++ b/app/src/main/res/layout/toolbar_add_layout.xml
@@ -29,7 +29,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="?android:actionBarSize"
                 android:background="@color/main"
-                app:menu="@menu/label_add_menu"
+                app:menu="@menu/only_save_string_menu"
                 app:navigationIcon="@drawable/ic_back"
                 app:title="@{title}"
                 app:titleTextColor="@color/white"/>

--- a/app/src/main/res/layout/toolbar_edit_layout.xml
+++ b/app/src/main/res/layout/toolbar_edit_layout.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="editToolbarTitle"
+            type="String" />
+
+        <variable
+            name="defaultToolbarTitle"
+            type="String" />
+
+        <variable
+            name="editToolbarVisible"
+            type="Boolean" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/label_appbarLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:elevation="0dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/default_toolbar"
+                style="@style/Headline6"
+                android:layout_width="match_parent"
+                android:layout_height="?android:actionBarSize"
+                android:background="@color/white"
+                android:visibility="@{editToolbarVisible? View.GONE : View.VISIBLE}"
+                app:menu="@menu/label_default_menu"
+                app:title="@{defaultToolbarTitle}"
+                tools:title="타이틀" />
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/edit_toolbar"
+                style="@style/Headline6"
+                android:layout_width="match_parent"
+                android:layout_height="?android:actionBarSize"
+                android:background="@color/main"
+                android:visibility="@{editToolbarVisible? View.VISIBLE : View.GONE}"
+                app:menu="@menu/label_edit_menu"
+                app:navigationIcon="@drawable/ic_exit"
+                app:title="@{editToolbarTitle}"
+                app:titleTextColor="@color/white"
+                tools:visibility="gone" />
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/toolbar_edit_layout.xml
+++ b/app/src/main/res/layout/toolbar_edit_layout.xml
@@ -41,7 +41,7 @@
                 android:layout_height="?android:actionBarSize"
                 android:background="@color/white"
                 android:visibility="@{editToolbarVisible? View.GONE : View.VISIBLE}"
-                app:menu="@menu/label_default_menu"
+                app:menu="@menu/only_add_blue_icon_menu"
                 app:title="@{defaultToolbarTitle}"
                 tools:title="타이틀" />
 
@@ -52,7 +52,7 @@
                 android:layout_height="?android:actionBarSize"
                 android:background="@color/main"
                 android:visibility="@{editToolbarVisible? View.VISIBLE : View.GONE}"
-                app:menu="@menu/label_edit_menu"
+                app:menu="@menu/only_delete_white_icon_menu"
                 app:navigationIcon="@drawable/ic_exit"
                 app:title="@{editToolbarTitle}"
                 app:titleTextColor="@color/white"

--- a/app/src/main/res/menu/only_add_blue_icon_menu.xml
+++ b/app/src/main/res/menu/only_add_blue_icon_menu.xml
@@ -3,9 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/add_label"
+        android:id="@+id/add_blue_icon"
         android:icon="@drawable/ic_add_blue"
-        android:title="@string/label_add_menu_string"
+        android:title="@string/add_string"
         app:showAsAction="always" />
 
 </menu>

--- a/app/src/main/res/menu/only_delete_white_icon_menu.xml
+++ b/app/src/main/res/menu/only_delete_white_icon_menu.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+
     <item
-        android:id="@+id/label_save"
-        android:enabled="false"
-        android:title="@string/save_string"
+        android:id="@+id/delete_white_icon"
+        android:icon="@drawable/ic_delete"
+        android:title="@string/delete_string"
         app:showAsAction="always" />
+
 </menu>

--- a/app/src/main/res/menu/only_save_string_menu.xml
+++ b/app/src/main/res/menu/only_save_string_menu.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-
     <item
-        android:id="@+id/delete_label"
-        android:icon="@drawable/ic_delete"
-        android:title="@string/delete_label"
+        android:id="@+id/save_string"
+        android:enabled="false"
+        android:title="@string/save_string"
         app:showAsAction="always" />
-
 </menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -30,4 +30,10 @@
     <color name="light_blue">#42A5F5</color>
     <color name="light_sky">#0288D1</color>
     <color name="light_purple">#BA68C8</color>
+
+    <!-- milestone issue color -->
+    <color name="open_issue_bg_color">#C7EBFF</color>
+    <color name="open_issue_text_color">#004DE3</color>
+    <color name="close_issue_bg_color">#CCD4FF</color>
+    <color name="close_issue_text_color">#0025E7</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,5 +45,8 @@
     <!-- milestone -->
     <string name="milestone_complete_date">완료일</string>
     <string name="optional_input_date_string">선택 사항(YYYY-MM-DD)</string>
+    <string name="open_issue_string">열린 이슈 %d개</string>
+    <string name="close_issue_string">닫힌 이슈 %d개</string>
+    <string name="not_deadline_string">기한없음</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <!--toolbar title-->
     <string name="issue">이슈</string>
     <string name="label_add_string">새로운 레이블</string>
+    <string name="label_edit_string">레이블 수정</string>
     <string name="label_string">레이블</string>
     <string name="delete_label">delete label</string>
     <string name="select_items_count">선택된 항목 : %d개</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,8 +35,10 @@
     <string name="delete_label">delete label</string>
     <string name="select_items_count">선택된 항목 : %d개</string>
     <string name="select_label">레이블 선택</string>
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="not_found_result">검색 결과가 없습니다.</string>
+    <string name="milestone_toolbar_title_string">마일스톤</string>
+    <string name="milestone_toolbar_edit_string">마일스톤 선택</string>
+    <string name="milestone_toolbar_new_string">새로운 마일스톤</string>
+    <string name="calendar_image_content">calendar image</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,7 +12,6 @@
     <string name="bottom_navigation_my_page">내 계정</string>
 
     <!--label-->
-    <string name="label_add_menu_string">label add</string>
     <string name="save_string">저장</string>
     <string name="label_subject_string">제목</string>
     <string name="must_input_string">필수 입력</string>
@@ -33,7 +32,7 @@
     <string name="label_add_string">새로운 레이블</string>
     <string name="label_edit_string">레이블 수정</string>
     <string name="label_string">레이블</string>
-    <string name="delete_label">delete label</string>
+    <string name="delete_string">delete</string>
     <string name="select_items_count">선택된 항목 : %d개</string>
     <string name="select_label">레이블 선택</string>
     <string name="not_found_result">검색 결과가 없습니다.</string>
@@ -41,5 +40,10 @@
     <string name="milestone_toolbar_edit_string">마일스톤 선택</string>
     <string name="milestone_toolbar_new_string">새로운 마일스톤</string>
     <string name="calendar_image_content">calendar image</string>
+    <string name="add_string">add</string>
+
+    <!-- milestone -->
+    <string name="milestone_complete_date">완료일</string>
+    <string name="optional_input_date_string">선택 사항(YYYY-MM-DD)</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,5 +48,8 @@
     <string name="open_issue_string">열린 이슈 %d개</string>
     <string name="close_issue_string">닫힌 이슈 %d개</string>
     <string name="not_deadline_string">기한없음</string>
+    <string name="milestone_add_string">새로운 마일스톤</string>
+    <string name="milestone_edit_string">마일스톤 수정</string>
+    <string name="clear_date_string">날짜 초기화</string>
 
 </resources>


### PR DESCRIPTION
## ❗️ 이슈 트래킹

- #19 

## 💡 작업목록

- 마일스톤 목록 및 추가/삭제/수정 구현
- 편집모드 구현

## ❓ 고민과 해결

- Label, Milestone에서 편집모드를 구현하기 위해 각각 ListAdapter를 구현했으나, data class를 제외하고는 모든 로직이 동일해 중복된 코드가 많은 것 같다고 생각했다. 그래서 팀원과 얘기한 결과 화면이 완전히 다른 경우 (연관성이 없는 경우)에는 비슷하더라도 나눠서 관리하는게 나중에 요구사항이 변경되어도 유연하게 대처할 수 있을 것 같다는 결론을 내렸다.
 