### PR TITLE
[BE] 마일스톤 조회 기능 수정

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker/dto/MilestoneResponse.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/dto/MilestoneResponse.java
@@ -1,6 +1,5 @@
 package kr.codesquad.issuetracker.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import kr.codesquad.issuetracker.domain.Issue;
 import kr.codesquad.issuetracker.domain.Milestone;
 import lombok.Getter;
@@ -21,14 +20,29 @@ public class MilestoneResponse {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate deadline;
 
-    @JsonIgnore
-    private List<Issue> issueList;
+    private int openedIssues;
+    private int closedIssues;
 
     public MilestoneResponse(Milestone milestone) {
         this.id = milestone.getId();
         this.title = milestone.getTitle();
         this.description = milestone.getContent();
         this.deadline = milestone.getDeadline();
-        this.issueList = milestone.getIssueList();
+        List<Issue> issueList = milestone.getIssueList();
+        countIssues(issueList);
+        this.openedIssues = getOpenedIssues();
+        this.closedIssues = getClosedIssues();
+    }
+
+
+    private void countIssues(List<Issue> issueList){
+        for (Issue issue : issueList) {
+            if (issue.isStatus()) {
+                openedIssues ++;
+            }
+            if (!issue.isStatus()){
+                closedIssues ++;
+            }
+        }
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/MilestoneService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/MilestoneService.java
@@ -21,7 +21,6 @@ public class MilestoneService {
 
     private final MilestoneRepository milestoneRepository;
 
-    //TODO: 열린이슈와 닫힌이슈 리스트 생성해서 리턴하기
     public List<MilestoneResponse> getMilestoneList() {
         return milestoneRepository.findAll().stream()
                 .map(MilestoneResponse::new).collect(Collectors.toList());


### PR DESCRIPTION
## ❗️ 이슈 트래킹

- #38 

## 💡 작업목록
- 열린 이슈와 닫힌 이슈 개수를 카운트하여 응답할 수 있도록 수정
<img width="534" alt="스크린샷 2022-06-28 오전 8 58 31" src="https://user-images.githubusercontent.com/87681380/176058936-411d92b6-321d-47c1-b1a3-52f1bb67117b.png">

