### PR TITLE
[BE] 레이블 편집 기능 구현

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/LabelController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/LabelController.java
@@ -31,11 +31,6 @@ public class LabelController {
 
     @DeleteMapping("/{id}")
     public ResponseEntity deleteLabel(@PathVariable Long id) {
-        try {
-            labelService.deleteLabel(id);
-        } catch (EmptyResultDataAccessException e) {
-            return new ResponseEntity(HttpStatus.BAD_REQUEST);
-        }
-        return new ResponseEntity(HttpStatus.OK);
+        return labelService.deleteLabel(id);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/LabelController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/LabelController.java
@@ -33,4 +33,9 @@ public class LabelController {
     public ResponseEntity deleteLabel(@PathVariable Long id) {
         return labelService.deleteLabel(id);
     }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity editLabel(@PathVariable Long id, @RequestBody LabelRequest labelRequest) {
+        return labelService.editLabel(id, labelRequest);
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/Label.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/Label.java
@@ -34,4 +34,20 @@ public class Label {
         this.backgroundColor = labelRequest.getColor();
         this.textColor = labelRequest.getTextColor();
     }
+
+    //TODO: 리팩토링 필요
+    public void update(LabelRequest labelRequest){
+        if (labelRequest.getTitle() != null) {
+            this.title = labelRequest.getTitle();
+        }
+        if (labelRequest.getDescription() != null) {
+            this.content = labelRequest.getDescription();
+        }
+        if (labelRequest.getColor() != null) {
+            this.backgroundColor = labelRequest.getColor();
+        }
+        if (labelRequest.getTextColor() != null) {
+            this.textColor = labelRequest.getTextColor();
+        }
+    }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/LabelService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/LabelService.java
@@ -5,6 +5,9 @@ import kr.codesquad.issuetracker.dto.LabelRequest;
 import kr.codesquad.issuetracker.dto.LabelResponse;
 import kr.codesquad.issuetracker.repository.LabelRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +31,12 @@ public class LabelService {
         labelRepository.save(label);
     }
 
-    public void deleteLabel(Long id){
-        labelRepository.deleteById(id);
+    public ResponseEntity deleteLabel(Long id){
+        try {
+            labelRepository.deleteById(id);
+        } catch (EmptyResultDataAccessException e) {
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/LabelService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/LabelService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -37,6 +38,12 @@ public class LabelService {
         } catch (EmptyResultDataAccessException e) {
             return new ResponseEntity(HttpStatus.BAD_REQUEST);
         }
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    public ResponseEntity editLabel(Long id, LabelRequest labelRequest) {
+        Label label = labelRepository.findById(id).orElseThrow(IllegalAccessError::new);
+        label.update(labelRequest);
         return new ResponseEntity(HttpStatus.OK);
     }
 }

--- a/BE/src/main/resources/data.sql
+++ b/BE/src/main/resources/data.sql
@@ -8,7 +8,8 @@ VALUES (1, '마일스톤1내용', '2022-07-01', '마일스톤1'),
 INSERT INTO label(id, title, content, background_color, text_color)
 VALUES (1, '레이블1', '레이블1설명', '#FFFF00', '#000000'),
        (2, '레이블2', '2설명', '#FFA500', '#000000'),
-       (3, '레이블3', '3설명', '#AFEEEE', '#000000');
+       (3, '레이블3', '3설명', '#AFEEEE', '#000000'),
+       (4, '레이블4', '4설명', '#AFEEEE', '#000000');
 
 INSERT INTO members(id, github_id, image_url, name)
     VALUE (1, 'leekm310', 'https://avatars.githubusercontent.com/u/87681380?v=4', 'K Lee');


### PR DESCRIPTION
## ❗️ 이슈 트래킹

- #48 

## 💡 작업목록

- 레이블 편집 기능 구현
`PATCH api/milestones/{id}`
![스크린샷 2022-06-28 오후 3 38 07](https://user-images.githubusercontent.com/87681380/176110252-e0faa000-d2b0-49a8-a9ad-2c6834aafe58.png)

