### PR TITLE
[BE] 이슈 상세 기능 구현

### DIFF
--- a/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/controller/IssueController.java
@@ -1,5 +1,6 @@
 package kr.codesquad.issuetracker.controller;
 
+import kr.codesquad.issuetracker.dto.IssueDetailResponse;
 import kr.codesquad.issuetracker.dto.IssueResponse;
 import kr.codesquad.issuetracker.dto.IssueStatusRequest;
 import kr.codesquad.issuetracker.service.IssueService;
@@ -25,4 +26,10 @@ public class IssueController {
                                           @RequestParam Boolean status) {
         return issueService.editStatus(issueStatusRequest, status);
     }
+
+    @GetMapping("/issues/{id}")
+    public IssueDetailResponse getIssueDetail(@PathVariable Long id){
+        return issueService.getIssueDetail(id);
+    }
+
 }

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/Comment.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/Comment.java
@@ -1,5 +1,6 @@
 package kr.codesquad.issuetracker.domain;
 
+import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
@@ -8,6 +9,7 @@ import java.time.LocalDateTime;
 import static javax.persistence.FetchType.LAZY;
 
 @Entity
+@Getter
 @Table(name = "comments")
 public class Comment {
 

--- a/BE/src/main/java/kr/codesquad/issuetracker/domain/IssueMembers.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/domain/IssueMembers.java
@@ -1,10 +1,13 @@
 package kr.codesquad.issuetracker.domain;
 
+import lombok.Getter;
+
 import javax.persistence.*;
 
 import static javax.persistence.FetchType.LAZY;
 
 @Entity
+@Getter
 public class IssueMembers {
 
     @Id

--- a/BE/src/main/java/kr/codesquad/issuetracker/dto/AssigneeResponse.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/dto/AssigneeResponse.java
@@ -1,0 +1,18 @@
+package kr.codesquad.issuetracker.dto;
+
+import kr.codesquad.issuetracker.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class AssigneeResponse {
+
+    private Long id;
+    private String githubId;
+    private String imageUrl;
+
+    public AssigneeResponse(Member member) {
+        this.id = member.getId();
+        this.githubId = member.getGithubId();
+        this.imageUrl = member.getImageUrl();
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker/dto/CommentResponse.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/dto/CommentResponse.java
@@ -1,0 +1,24 @@
+package kr.codesquad.issuetracker.dto;
+
+import kr.codesquad.issuetracker.domain.Comment;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentResponse {
+
+    private Long id;
+    private String content;
+    private LocalDateTime createdTime;
+    private String userId;
+    private String imageUrl;
+
+    public CommentResponse(Comment comment) {
+        this.id = comment.getId();
+        this.content = comment.getContent();
+        this.createdTime = comment.getCreatedTime();
+        this.userId = comment.getMember().getGithubId();
+        this.imageUrl = comment.getMember().getImageUrl();
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker/dto/IssueDetailResponse.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/dto/IssueDetailResponse.java
@@ -1,0 +1,37 @@
+package kr.codesquad.issuetracker.dto;
+
+import kr.codesquad.issuetracker.domain.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class IssueDetailResponse {
+
+    private Long id;
+    private String title;
+    private boolean status;
+    private LocalDateTime createdTime;
+    private String content;
+    private MemberResponse writer;
+    private List<AssigneeResponse> assignees;
+    private List<CommentResponse> comments;
+    private List<LabelResponse> labels;
+    private MilestoneResponse milestone;
+
+    @Builder
+    public IssueDetailResponse(Issue issue, MemberResponse writer, List<AssigneeResponse> assignees, List<CommentResponse> comments, List<LabelResponse> labels, MilestoneResponse milestone) {
+        this.id = issue.getId();
+        this.title = issue.getTitle();
+        this.status = issue.isStatus();
+        this.createdTime = issue.getCreatedTime();
+        this.content = issue.getContent();
+        this.writer = writer;
+        this.assignees = assignees;
+        this.comments = comments;
+        this.labels = labels;
+        this.milestone = milestone;
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker/dto/MemberResponse.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/dto/MemberResponse.java
@@ -1,0 +1,22 @@
+package kr.codesquad.issuetracker.dto;
+
+import kr.codesquad.issuetracker.domain.Member;
+import lombok.Getter;
+
+@Getter
+public class MemberResponse {
+
+    private Long id;
+    private String name;
+    private String email;
+    private String githubId;
+    private String imageUrl;
+
+    public MemberResponse(Member member) {
+        this.id = member.getId();
+        this.name = member.getName();
+        this.email = member.getEmail();
+        this.githubId = member.getGithubId();
+        this.imageUrl = member.getImageUrl();
+    }
+}

--- a/BE/src/main/java/kr/codesquad/issuetracker/service/IssueService.java
+++ b/BE/src/main/java/kr/codesquad/issuetracker/service/IssueService.java
@@ -1,7 +1,9 @@
 package kr.codesquad.issuetracker.service;
 
-import kr.codesquad.issuetracker.dto.IssueResponse;
-import kr.codesquad.issuetracker.dto.IssueStatusRequest;
+import kr.codesquad.issuetracker.domain.Issue;
+import kr.codesquad.issuetracker.domain.IssueLabels;
+import kr.codesquad.issuetracker.domain.IssueMembers;
+import kr.codesquad.issuetracker.dto.*;
 import kr.codesquad.issuetracker.repository.IssueRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,5 +30,18 @@ public class IssueService {
         List<Long> issueList = issueStatusRequest.getIssueList();
         issueRepository.updateStatus(status, issueList);
         return new ResponseEntity(HttpStatus.OK);
+    }
+
+    //TODO: 리팩토링 필요..
+    public IssueDetailResponse getIssueDetail(Long id){
+        Issue issue = issueRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        return IssueDetailResponse.builder()
+                .issue(issue)
+                .labels(issue.getIssueLabelsList().stream().map(IssueLabels::getLabel).map(LabelResponse::new).collect(Collectors.toList()))
+                .milestone(new MilestoneResponse(issue.getMilestone()))
+                .comments(issue.getCommentList().stream().map(CommentResponse::new).collect(Collectors.toList()))
+                .writer(new MemberResponse(issue.getMember()))
+                .assignees(issue.getIssueMembersList().stream().map(IssueMembers::getMember).map(AssigneeResponse::new).collect(Collectors.toList()))
+                .build();
     }
 }

--- a/BE/src/main/resources/data.sql
+++ b/BE/src/main/resources/data.sql
@@ -12,7 +12,8 @@ VALUES (1, '레이블1', '레이블1설명', '#FFFF00', '#000000'),
        (4, '레이블4', '4설명', '#AFEEEE', '#000000');
 
 INSERT INTO members(id, github_id, image_url, name)
-    VALUE (1, 'leekm310', 'https://avatars.githubusercontent.com/u/87681380?v=4', 'K Lee');
+VALUES (1, 'leekm310', 'https://avatars.githubusercontent.com/u/87681380?v=4', 'K Lee'),
+       (2, 'tester1', 'https://www.business2community.com/wp-content/uploads/2017/08/blank-profile-picture-973460_640.png', 'tester');
 
 INSERT INTO issue(id, content, title, created_time, issues_status, member_id, milestone_id)
 VALUES (1, '테스트1', '테스트입니다1', '2022-07-06 12:00:00', false , 1, 1),
@@ -25,4 +26,12 @@ INSERT INTO issue_labels(id, issue_id, label_id)
 VALUES (1, 2, 1),
        (2, 2, 2),
        (3, 3, 3);
+
+INSERT INTO  issue_members(id, issue_id, member_id)
+VALUES (1, 2, 1),
+       (2, 3, 2);
+
+INSERT INTO comments(id, content, created_time, issue_id, member_id)
+VALUE (1, '코멘트테스트', '2022-07-08 13:42:00', 2, 1);
+
 


### PR DESCRIPTION
## ❗️ 이슈 트래킹

- #59 

## 💡 작업목록

- 이슈 상세 조회 기능 구현
`GET api/issues/{id}`
<img width="797" alt="스크린샷 2022-06-30 오후 12 28 39" src="https://user-images.githubusercontent.com/87681380/176586756-3633c8b2-fc07-419f-ac99-2b3787301a8a.png">

